### PR TITLE
Added access to EngineService's message poll timer from AppTimers

### DIFF
--- a/ChessForge/AppTimers.cs
+++ b/ChessForge/AppTimers.cs
@@ -9,17 +9,22 @@ using System.Diagnostics;
 namespace ChessForge
 {
     /// <summary>
-    /// Encapsulates all timers and stopwatches used in the application
+    /// Encapsulates all timers and stopwatches used in the application.
+    /// The timer for polling engine messages can be accessed from here too for
+    /// interface consistency. However, it is created and manipulated within the
+    /// Engine Service.
     /// </summary>
     internal class AppTimers
     {
         /// <summary>
         /// Ids of all timers used by the application
         /// </summary>
-        internal enum TimerId{
+        internal enum TimerId
+        {
             DUMMY,
             EVALUTION_LINE_DISPLAY,
-            CHECK_FOR_USER_MOVE
+            CHECK_FOR_USER_MOVE,
+            ENGINE_MESSAGE_POLL
         };
 
         internal enum StopwatchId
@@ -39,12 +44,6 @@ namespace ChessForge
         /// requests appropriate processing.
         /// </summary>
         private Timer _checkForUserMoveTimer = new Timer();
-
-        /// <summary>
-        /// This timer invokes the method checking for new messages
-        /// from the engine.
-        /// </summary>
-        private Timer _engineMessagePollTimer = new Timer();
 
         /// <summary>
         /// Tracks time that evaluation of a move/position is taking.
@@ -79,14 +78,32 @@ namespace ChessForge
             _dictStopwatches.Add(StopwatchId.EVALUTION_PROGRESS, _evaluationProgressStopwatch);
         }
 
+        /// <summary>
+        /// Handles EMGINE_MESSAGE_POLL timer as a special case.
+        /// </summary>
+        /// <param name="tt"></param>
         public void Start(TimerId tt)
         {
-            _dictTimers[tt].Enabled = true;
+            if (tt == TimerId.ENGINE_MESSAGE_POLL)
+            {
+                EngineMessageProcessor.ChessEngineService.StartMessagePollTimer();
+            }
+            else
+            {
+                _dictTimers[tt].Enabled = true;
+            }
         }
 
         public void Stop(TimerId tt)
         {
-            _dictTimers[tt].Enabled = false;
+            if (tt == TimerId.ENGINE_MESSAGE_POLL)
+            {
+                EngineMessageProcessor.ChessEngineService.StopMessagePollTimer();
+            }
+            else
+            {
+                _dictTimers[tt].Enabled = false;
+            }
         }
 
         public void Start(StopwatchId sw)

--- a/ChessForge/EngineMessageProcessor.cs
+++ b/ChessForge/EngineMessageProcessor.cs
@@ -15,15 +15,16 @@ namespace ChessForge
     {
 
         public static MainWindow MainWin;
+
         public static void CreateEngineService(MainWindow win, bool debugMode)
         {
             MainWin = win;
-            _ChessEngine = new EngineService.StockfishService(debugMode);
-            _ChessEngine.EngineMessage += EngineMessageReceived;
+            ChessEngineService = new EngineService.EngineProcess(debugMode);
+            ChessEngineService.EngineMessage += EngineMessageReceived;
         }
 
         // an instance of the engine service
-        private static EngineService.StockfishService _ChessEngine;
+        public static EngineService.EngineProcess ChessEngineService;
 
         /// <summary>
         /// The list of candidates retruned by the engine.
@@ -45,12 +46,14 @@ namespace ChessForge
 
         public static void StartMessagePollTimer()
         {
-            _ChessEngine.StartMessagePollTimer(); 
+            MainWin.Timers.Start(AppTimers.TimerId.ENGINE_MESSAGE_POLL);
+//            ChessEngineService.StartMessagePollTimer(); 
         }
 
         public static void StopMessagePollTimer()
         {
-            _ChessEngine.StopMessagePollTimer();
+            MainWin.Timers.Stop(AppTimers.TimerId.ENGINE_MESSAGE_POLL);
+//            ChessEngineService.StopMessagePollTimer();
         }
 
         /// <summary>
@@ -71,18 +74,18 @@ namespace ChessForge
 
         public static bool IsEngineAvailable()
         {
-            return _ChessEngine.IsEngineReady;
+            return ChessEngineService.IsEngineReady;
         }
 
         public static void SendCommand(string cmd)
         {
             AppLog.Message("Tx Command: " + cmd);
-            _ChessEngine.SendCommand(cmd);
+            ChessEngineService.SendCommand(cmd);
         }
 
         public static bool Start()
         {
-            return _ChessEngine.StartEngine();
+            return ChessEngineService.StartEngine();
         }
 
         /// <summary>

--- a/ChessForge/MainWindow.xaml.cs
+++ b/ChessForge/MainWindow.xaml.cs
@@ -75,6 +75,7 @@ namespace ChessForge
             _menuPlayComputer.Header = Strings.MENU_ENGINE_GAME_START;
 
             _engineEvaluationGUI = new EngineEvaluationGUI(_tbEngineLines, _pbEngineThinking, Evaluation);
+            Timers = new AppTimers(_engineEvaluationGUI);
 
             Configuration.Initialize(this);
             Configuration.StartDirectory = Directory.GetCurrentDirectory();
@@ -136,7 +137,6 @@ namespace ChessForge
 
         private void Window_Loaded(object sender, RoutedEventArgs e)
         {
-            Timers = new AppTimers(_engineEvaluationGUI);
 
             _rtbWorkbookView.Document.Blocks.Clear();
             _rtbWorkbookView.IsReadOnly = true;
@@ -861,7 +861,7 @@ namespace ChessForge
             ShowMoveEvaluationControls(true, isLineStart);
             UpdateLastMoveTextBox(posIndex, isLineStart);
 
-            EngineMessageProcessor.StartMessagePollTimer();
+            Timers.Start(AppTimers.TimerId.ENGINE_MESSAGE_POLL);
 
             PrepareMoveEvaluation(mode, Evaluation.Position);
         }
@@ -887,7 +887,7 @@ namespace ChessForge
             Evaluation.Position = nd.Position;
             ShowMoveEvaluationControls(true, false);
 
-            EngineMessageProcessor.StartMessagePollTimer();
+            Timers.Start(AppTimers.TimerId.ENGINE_MESSAGE_POLL);
             PrepareMoveEvaluation(EvaluationState.EvaluationMode.IN_TRAINING, Evaluation.Position);
         }
 
@@ -971,7 +971,7 @@ namespace ChessForge
                 ProcessEngineGameMoveEvent();
                 Evaluation.PrepareToContinue();
 
-                EngineMessageProcessor.StopMessagePollTimer();
+                Timers.Stop(AppTimers.TimerId.ENGINE_MESSAGE_POLL);
             }
             else
             {
@@ -1222,7 +1222,7 @@ namespace ChessForge
             MainChessBoard.DisplayPosition(pos);
             EngineGame.State = EngineGame.GameState.USER_THINKING;
             Timers.Start(AppTimers.TimerId.CHECK_FOR_USER_MOVE);
-            EngineMessageProcessor.StopMessagePollTimer();
+            Timers.Stop(AppTimers.TimerId.ENGINE_MESSAGE_POLL);
         }
 
         /// <summary>
@@ -1299,7 +1299,7 @@ namespace ChessForge
 
             imgChessBoard.Source = ChessBoards.ChessBoardBlue;
             Evaluation.Reset();
-            EngineMessageProcessor.StopMessagePollTimer();
+            Timers.Stop(AppTimers.TimerId.ENGINE_MESSAGE_POLL);
             AppState.CurrentMode = AppState.Mode.MANUAL_REVIEW;
             EngineGame.State = EngineGame.GameState.IDLE;
             Timers.Stop(AppTimers.TimerId.CHECK_FOR_USER_MOVE);

--- a/EngineService/StockfishService.cs
+++ b/EngineService/StockfishService.cs
@@ -10,23 +10,46 @@ using System.Threading.Tasks;
 
 namespace EngineService
 {
-    public class StockfishService : IEngineService
+    /// <summary>
+    /// This class starts the engine service and provides a means of
+    /// communicating with it.
+    /// It is built as a DLL so that it can be easily tested independent of the main program.
+    /// </summary>
+    public class EngineProcess : IEngineService
     {
+        // true if the engine is running ready to accept requets
         public bool IsEngineRunning = false;
+        
+        // true if we have received "readyok" from the engine 
         public bool IsEngineReady = false;
 
+        // reads engine process's STDOUT 
         private StreamReader strmReader;
+
+        // writes to engine process's STDIN 
         private StreamWriter strmWriter;
+
+        // the engine service process
         private Process engineProcess;
 
+        /// <summary>
+        /// Action invoked by ReadEngineMessage().
+        /// It is defined in EngineMessageProcessor as EngineMessageReceived().
+        /// </summary>
         public event Action<string> EngineMessage;
 
+        // if true, engine's messages will be logged
         private bool _debugMode;
 
-        private Timer MessagePollTimer = new System.Timers.Timer();
+        // the timer polling for engine's messages
+        private Timer MessagePollTimer = new Timer();
 
 
-        public StockfishService(bool debugMode)
+        /// <summary>
+        /// Creates the Engine Service object.
+        /// </summary>
+        /// <param name="debugMode"></param>
+        public EngineProcess(bool debugMode)
         {
             _debugMode = debugMode;
             if (_debugMode)
@@ -35,6 +58,11 @@ namespace EngineService
             }
         }
 
+        /// <summary>
+        /// Starts the engine process.
+        /// Initializes all relevant objects and variables.
+        /// </summary>
+        /// <returns></returns>
         public bool StartEngine()
         {
             //FileInfo engine = new FileInfo(Path.Combine(Environment.CurrentDirectory, "stockfish_8_x64.exe"));
@@ -57,6 +85,7 @@ namespace EngineService
                     strmReader = engineProcess.StandardOutput;
 
                     CreateTimer();
+
                     // start the message polling timer
                     // it will be stopped when ok is received
                     StartMessagePollTimer();
@@ -80,11 +109,13 @@ namespace EngineService
             }
         }
 
+        /// <summary>
+        /// Stops the engine process.
+        /// </summary>
         public void StopEngine()
         {
             if (engineProcess != null && !engineProcess.HasExited)
             {
-                //engineListener.Dispose();
                 strmReader.Close();
                 strmWriter.Close();
             }
@@ -107,6 +138,22 @@ namespace EngineService
             }
         }
 
+        /// <summary>
+        /// Starts the message poll timer.
+        /// </summary>
+        public void StartMessagePollTimer()
+        {
+            MessagePollTimer.Enabled = true;
+        }
+
+        /// <summary>
+        /// Stops the message poll timer
+        /// </summary>
+        public void StopMessagePollTimer()
+        {
+            MessagePollTimer.Enabled = false;
+        }
+
 
         /// <summary>
         /// Creates a timer to poll for engine messages.
@@ -118,19 +165,14 @@ namespace EngineService
             MessagePollTimer.Elapsed += new ElapsedEventHandler(ReadEngineMessages);
         }
 
-        public void StartMessagePollTimer()
-        {
-            MessagePollTimer.Enabled = true;
-        }
-        public void StopMessagePollTimer()
-        {
-            MessagePollTimer.Enabled = false;
-        }
-
-        public static object EngineLock = new object();
+        /// <summary>
+        /// A lock object to use when reading engine messages
+        /// </summary>
+        private static object EngineLock = new object();
 
         /// <summary>
-        /// Called periodically to check on messages from the engine.
+        /// Called periodically in response to MessagePollTimer's elapse event
+        /// to check on messages from the engine.
         /// Invokes the message handler to process the info.
         /// </summary>
         /// <param name="source"></param>

--- a/StockfishTest/Program.cs
+++ b/StockfishTest/Program.cs
@@ -14,7 +14,7 @@ namespace StockfishTest
     {
         private static StringBuilder txtMessageFile = new StringBuilder();
 
-        private static EngineService.StockfishService engine;
+        private static EngineService.EngineProcess engine;
         private static MoveEval[] mev = new MoveEval[5];
         private static bool IsEngineReady = false;
 
@@ -27,7 +27,7 @@ namespace StockfishTest
 
         static void Main(string[] args)
         {
-            engine = new EngineService.StockfishService(true);
+            engine = new EngineService.EngineProcess(true);
             engine.EngineMessage += EngineMessage;
 
             StartStockfishEngine(engine);
@@ -45,7 +45,7 @@ namespace StockfishTest
 
         }
 
-        private static void StartStockfishEngine(EngineService.StockfishService engine)
+        private static void StartStockfishEngine(EngineService.EngineProcess engine)
         {
             engine.StartEngine();
 


### PR DESCRIPTION
- Added ability to control the EngineService's MessagePollTimer in a way consistent with how other timers are accessed.
- Renamed StockfishService to EngineProcess (as is is not Stockfish specific).
- Added comments.