### PR TITLE
Prep for release 1.3.9 (fixed the last crashing issue)

### DIFF
--- a/ChessForge/IntroView.cs
+++ b/ChessForge/IntroView.cs
@@ -1336,7 +1336,6 @@ namespace ChessForge
             if (RichTextBoxUtilities.GetDiagramFromParagraph(para, out InlineUIContainer diagram))
             {
                 CleanupDiagramPara(para, diagram);
-                AppState.DoEvents();
             }
             else
             {


### PR DESCRIPTION
Removed call AppState.DoEvents() which was crashing the program in the Intro when typing immediately after the diagram in Tamil.